### PR TITLE
[auth] - Fix token decode failure

### DIFF
--- a/ibmcloud_python_sdk/auth.py
+++ b/ibmcloud_python_sdk/auth.py
@@ -15,7 +15,8 @@ def decode_token():
     """
     try:
         token = get_headers()["Authorization"]
-        return decode(token.split(" ")[1], verify=False)
+        return decode(token.split(" ")[1], verify=False,
+                      options={'verify_signature': False})
 
     except Exception as error:
         print("Error decoding token. {}".format(error))

--- a/ibmcloud_python_sdk/auth.py
+++ b/ibmcloud_python_sdk/auth.py
@@ -15,8 +15,11 @@ def decode_token():
     """
     try:
         token = get_headers()["Authorization"]
-        return decode(token.split(" ")[1], verify=False,
-                      options={'verify_signature': False})
+        return decode(
+            token.split(" ")[1],
+            algorithms=["RS256"],
+            options={"verify_signature": False},
+        )
 
     except Exception as error:
         print("Error decoding token. {}".format(error))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 PyYAML>=3.12
 softlayer==5.8.7
-PyJWT==2.4.0
+PyJWT==2.8.0
 ibm-cos-sdk==2.6.2
 botocore>=1.16.9
 pymemcache==3.2.0
+cryptography==42.0.5


### PR DESCRIPTION
While decoding, the "decode_token" function fails with the following message:

"The error was: jwt.exceptions.DecodeError: It is required that you pass in a value for the "algorithms" argument when calling decode()"

Adding the "'verify_signature': False" option to override the failure.